### PR TITLE
remove border its no longer used

### DIFF
--- a/adm/style/stopforumspam_body.html
+++ b/adm/style/stopforumspam_body.html
@@ -5,7 +5,7 @@
 	<legend>{{ lang('BUY_ME_A_BEER') }}</legend>
 	<dl>
 		<dt><label>{{ lang('BUY_ME_A_BEER_SHORT') }}{{ lang('COLON') }}</label><br /><span>{{ lang('BUY_ME_A_BEER_EXPLAIN') }}</span></dt>
-		<dd><a href="{{ lang('BUY_ME_A_BEER_URL') }}" target="_blank" rel="noreferrer noopener"><img src="{{ lang('PAYPAL_IMAGE_URL') }}" border="0" alt="{{ lang('PAYPAL_ALT') }}" style="cursor:pointer;margin-top:15px;"></a></dd>
+		<dd><a href="{{ lang('BUY_ME_A_BEER_URL') }}" target="_blank" rel="noreferrer noopener"><img src="{{ lang('PAYPAL_IMAGE_URL') }}" alt="{{ lang('PAYPAL_ALT') }}" style="cursor: pointer; margin-top: 15px;"></a></dd>
 	</dl>
 </fieldset>
 {% if CURL_ACTIVE %}


### PR DESCRIPTION
ran html validator on the acp page and noticed this
Warning: The border attribute is obsolete. Consider specifying img { border: 0; } in CSS instead.